### PR TITLE
Make Powered by Booqable a link

### DIFF
--- a/kylie/assets/footer.css
+++ b/kylie/assets/footer.css
@@ -162,6 +162,15 @@
   color: var(--color-primary-foreground);
 }
 
+.footer__copyright a {
+  color: var(--color-primary-foreground);
+  text-decoration: none;
+}
+
+.footer__copyright a:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 576px) {
   .footer__copyright {
     text-align: center;

--- a/kylie/sections/footer.liquid
+++ b/kylie/sections/footer.liquid
@@ -57,7 +57,7 @@
   {% if section.settings.show_copyright %}
     <div class="footer__bottom">
       <div class="footer__copyright footer__copyright--align-{{ section.settings.align_copyright }}">
-        &copy; {{ "now" | date: "%Y" }}, {{ shop.name }}{% if section.settings.show_powered_by %} | Powered by Booqable{% endif %}        
+        &copy; {{ "now" | date: "%Y" }}, {{ shop.name }}{% if section.settings.show_powered_by %} | <a href="https://booqable.com/?source=Shop&campaign=Cart" target="_blank" title="Powered by Booqable Rental Software">Powered by Booqable</a>{% endif %}
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Make the Powered by Booqable link in the footer a link to our website, just like it is in the cart.

~~I had no clue how to actually test this in my local env, so I did this without seeing it 🙈 
If some of you have some time to explain me how to run this in development, that would be nice 🙏 
On the other hand, the changes are pretty simple, so If you trust it, merge it :)~~

I checked it, looks good!
![Screenshot 2022-10-13 at 10 42 59](https://user-images.githubusercontent.com/106335/195547940-97dd593d-df22-4e1a-83d4-dcddb30dc008.png)
