### PR TITLE
Fix for the blank SEO title and description

### DIFF
--- a/kylie/layout/theme.liquid
+++ b/kylie/layout/theme.liquid
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-  {% if page_description %}<meta name="description" content="{{ page_description }}" >{% endif %}
-
   {% comment %} Base stylesheets {% endcomment %}
   {{ "base.css" | asset_url | stylesheet_tag }}
   {{ "rx.css" | asset_url | stylesheet_tag }}
@@ -44,28 +41,29 @@
     }
   </style>
 
-  {% if page_title %}
-    <title>{{ page_title }}</title>
-    <meta property="og:title" content="{{ page_title }}" />
-    <meta name="twitter:title" content="{{ page_title }}">
-  {% else %}
+  {% if page_title == blank %}
     <title>{{ shop.name }}</title>
-    <meta property="og:title" content="{{ shop.name }}" />
+    <meta property="og:title" content="{{ shop.name }}">
     <meta name="twitter:title" content="{{ shop.name }}">
+  {% else %}
+    <title>{{ page_title }}</title>
+    <meta property="og:title" content="{{ page_title }}">
+    <meta name="twitter:title" content="{{ page_title }}">
   {% endif %}
-  {% if page_description %}
-    <meta property="og:description" content="{{ page_description }}" />
+  {% if page_description != blank %}
+    <meta name="description" content="{{ page_description }}">
+    <meta property="og:description" content="{{ page_description }}">
     <meta name="twitter:description" content="{{ page_description }}">
   {% endif %}
-  <meta name="twitter:card" content="summary" />
-  <meta property="og:locale" content="{{ locale }}" />
+  <meta name="twitter:card" content="summary">
+  <meta property="og:locale" content="{{ locale }}">
 
   {% if product == blank %}
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="{{ canonical_url }}" />
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ canonical_url }}">
   {% else %}
     <meta property="og:type" content="product">
-    <meta property="og:url" content="{{ product.url }}" />
+    <meta property="og:url" content="{{ product.url }}">
 
     {% assign image = product.images.first %}
     {% if image.url != blank %}


### PR DESCRIPTION
Sometimes `page_title` and `page_description` values used in meta tags can be an empty string, which renders to
`<meta name="description" content>` which is not desirable.

To correct this, I've changed `{% if page_description %}` to `{% if page_description != blank %}`

Additionally, I've corrected the closing of the `<meta>` tag: from `/>` to `>` to be consistent with the [W3C standard](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-meta-element.html).