### PR TITLE
Fix: No vertical spacing on mobile for products

### DIFF
--- a/kylie/assets/products.css
+++ b/kylie/assets/products.css
@@ -24,6 +24,7 @@
   justify-content: center;
 
   gap: 16px;
+  padding: 0 var(--horizontal-padding);
 }
 
 .products__inner .product {
@@ -65,5 +66,7 @@
 
   .products__inner {  
     gap: 32px;
+
+    padding: 0;
   }
 }


### PR DESCRIPTION
Fixes an issue mentioned in [this thread](https://booqable.slack.com/archives/CE98ZB8E6/p1673900697892959)