### PR TITLE
Remove conditional powered by setting

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -58,7 +58,7 @@
   {% if section.settings.show_copyright %}
     <div class="footer__bottom">
       <div class="footer__copyright footer__copyright--align-{{ section.settings.align_copyright }}">
-        &copy; {{ "now" | date: "%Y" }}, {{ shop.name }}{% if section.settings.show_powered_by %} | <a href="https://booqable.com/?source=Shop&campaign=Cart" target="_blank" title="Powered by Booqable Rental Software">Powered by Booqable</a>{% endif %}
+        &copy; {{ "now" | date: "%Y" }}, {{ shop.name }} | <a href="https://booqable.com/?source=Shop&campaign=Cart" target="_blank" title="Powered by Booqable Rental Software">Powered by Booqable</a>
       </div>
     </div>
   {% endif %}
@@ -79,11 +79,6 @@
       "type": "checkbox",
       "id": "show_copyright",
       "label": "Show copyright"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_powered_by",
-      "label": "Show Powered by Booqable"
     }
   ],
   "blocks": [


### PR DESCRIPTION
This change comes from a roadmap meeting. We've had a spike in SEO ranking and signups due to this powered by backlink scoring really well. This PR makes sure you are unable to remove this link for now while it's in beta. We will allow to remove this link later again in specific plans.