### PR TITLE
Make header menus scrollable

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -102,6 +102,9 @@
 
 .header__nav .list-submenu__container {
   background-color: var(--color-primary-background);
+
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
 }
 
 .header__nav--mobile .list-menu .list-menu__item-caret {


### PR DESCRIPTION
Fixes issue of unreachable menu items.

Before:
<img width="663" alt="image" src="https://github.com/booqable/kylie-theme/assets/1877965/e39f1238-4b81-421d-8bdc-21a4b9dc9d36">

After:
<img width="650" alt="image" src="https://github.com/booqable/kylie-theme/assets/1877965/732a1173-373a-4931-a6da-38aa1a86ebb7">
