### PR TITLE
Fix: Menus accessibility

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -1,3 +1,7 @@
+.preview-bar__container ~ .header .header-floating-menu__wrapper {
+  height: calc(100vh - 180px);
+}
+
 .header {
   position: relative;
 
@@ -62,12 +66,164 @@
 }
 
 .header__nav-item:hover {
-  text-decoration: underline;
   text-decoration-color: var(--color-primary-foreground);
 }
 
 .header__nav--desktop {
   padding: 0 20px;
+}
+
+.header__nav--desktop .header__nav-item {
+  display: grid;
+  grid-template-columns: 1fr min-content;
+
+  align-items: center;
+
+  position: relative;
+}
+
+.header__nav--desktop .list-menu > .header__nav-item > .header__nav-submenu {
+  box-shadow: 0 1px 2px #213b471f, 0 4px 12px #213b471f;
+}
+
+.header__nav--desktop .header__nav-submenu {
+  visibility: hidden;
+  pointer-events: none;
+
+  position: absolute;
+
+  min-width: 250px;
+
+  background-color: var(--color-primary-background);
+
+  border-radius: var(--border-radius-sm);
+
+  top: calc(100% + 5px);
+  left: 0;
+
+  opacity: 0;
+
+  padding: 4px 0;
+
+  transform: translateY(20px);
+
+  max-height: calc(100vh - 150px);
+
+  overflow-y: auto;
+
+  transition: visibility 0ms, opacity 200ms, transform 150ms;
+}
+
+.header__nav--desktop .header__nav-submenu .header__nav-link {
+  font-weight: var(--font-weight-regular);
+}
+
+.header__nav--desktop
+  .header__nav-submenu
+  .header__nav-submenu
+  .header__nav-link {
+  opacity: 0.6;
+}
+
+.header__nav--desktop
+  .header__nav-submenu
+  .header__nav-submenu
+  .header__nav-link:hover {
+  opacity: 1;
+}
+
+.header__nav--desktop .header__nav-item label {
+  cursor: pointer;
+}
+
+.header__nav--desktop .header__nav-submenu .header__nav-item label {
+  width: 40px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header__nav--desktop .header__nav-link {
+  padding: 12px 16px;
+
+  color: var(--color-primary-foreground);
+
+  text-decoration: none;
+
+  position: relative;
+}
+
+.header__nav--desktop .header__nav-item-carer {
+  color: var(--color-primary-foreground);
+}
+
+.header__nav--desktop .header__nav-link:hover {
+  text-decoration: none;
+}
+
+.header__nav--desktop .header__nav-link:hover span {
+  padding-bottom: 3px;
+
+  border-bottom: 2px solid var(--color-accent-background);;
+}
+
+.header__nav--desktop .header__nav-submenu .header__nav-submenu {
+  position: relative;
+  grid-column: 1 / -1;
+
+  top: 0;
+
+  transform: none;
+  max-height: 0;
+
+  border-radius: 0;
+
+  padding: 0;
+}
+
+.header__nav--desktop
+  .header__nav-submenu
+  .header__nav-submenu
+  .header__nav-link {
+  padding-left: 40px;
+}
+
+.header__nav--desktop input[type="checkbox"] {
+  display: none;
+}
+
+.header__nav--desktop input[type="checkbox"]:checked ~ .header__nav-submenu {
+  visibility: visible;
+  pointer-events: all;
+
+  transform: translateY(0);
+
+  opacity: 1;
+}
+
+.header__nav--desktop input[type="checkbox"] ~ label > i {
+  transition: transform 100ms;
+
+  pointer-events: none;
+}
+
+.header__nav--desktop input[type="checkbox"] ~ label:hover > i {
+  transform: translateY(2px);
+}
+
+.header__nav--desktop input[type="checkbox"]:checked ~ label > i {
+  transform: rotate(180deg);
+}
+
+.header__nav--desktop
+  .header__nav-submenu
+  input[type="checkbox"]:checked
+  ~ .header__nav-submenu {
+  visibility: visible;
+  pointer-events: all;
+
+  max-height: 100%;
 }
 
 .header__nav .list-menu--horizontal > .list-menu__item:not(:last-child) {
@@ -270,7 +426,7 @@
 
   transition: visibility 0s linear 300ms, opacity 300ms, transform 250ms;
 
-  height: 100vh;
+  height: calc(100vh - 60px);
 
   background-color: var(--color-primary-background);
 
@@ -308,6 +464,8 @@
 @media (max-width: 762px) {
   .header__wrapper {
     grid-template-columns: 1fr repeat(2, 50px);
+
+    height: 60px;
   }
 
   .header__wrapper--with-menu {

--- a/assets/menus.js
+++ b/assets/menus.js
@@ -1,15 +1,40 @@
-const triggers = document.querySelectorAll(".list-menu__item:has(.list-submenu)");
+let target;
+let menu;
 
-const handleMeasure = (e) => {
-  const submenu = e.target.querySelector(".list-submenu");
+const handleCollapseMenus = () => {
+  if (target) {
+    target.checked = false;
 
-  const { y, height } = submenu.getBoundingClientRect();
+    menu.querySelectorAll('input[type="checkbox"]').forEach((toggle) => {
+      toggle.checked = false;
+    });
 
-  if (y + height > window.innerHeight) {
-    submenu.classList.add("list-submenu--bottom");
+    target = null;
+    menu = null;
   }
 };
 
-triggers.forEach((trigger) => {
-  trigger.addEventListener("mouseenter", handleMeasure);
+const handleMenuClicks = (e) => {
+  if (e.target.tagName === "LABEL") return;
+
+  if (e.target.type === "checkbox" && e.target.hasAttribute("data-toggle")) {
+    if (target || menu) {
+      handleCollapseMenus();
+    } else {
+      target = e.target;
+      menu = e.target.parentNode.querySelector(".header__nav-submenu");
+    }
+  }
+
+  if (target && !target?.contains(e.target) && !menu?.contains(e.target)) {
+    handleCollapseMenus();
+  }
+};
+
+document.addEventListener("click", handleMenuClicks);
+
+const links = document.querySelectorAll("a");
+
+links.forEach((link) => {
+  link.addEventListener("click", handleCollapseMenus);
 });

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -5,16 +5,17 @@
   {% if section.settings.background_color != blank %}
     .header,
     .header__wrapper,
-    .header__nav .list-submenu__container,
+    .header__nav .list-submenu,
+    .header__nav-submenu,
     .header-search__input,
     .header-floating-menu__wrapper,
     .header-search__wrapper {
-      background-color: {{ section.settings.background_color }};
+      background-color: {{ section.settings.background_color }} !important;
     }
 
     .header-search__input:autofill,
     .header-search__input:-webkit-autofill {
-      background-color: {{ section.settings.background_color }};
+      background-color: {{ section.settings.background_color }} !important;
     }
   {% endif %}
 
@@ -25,24 +26,22 @@
     .header-search__icon,
     .header-cart .bq-icon-cart::before,
     .header-floating-menu__icon,
-    .header__nav .list-menu__item .list-menu__item-caret {
-      color: {{ section.settings.foreground_color }};
+    .header__nav .list-menu__item .list-menu__item-caret,
+    .header__nav .header__nav-item-caret,
+    .header__nav .header__nav-link {
+      color: {{ section.settings.foreground_color }} !important;
     }
 
     .header-search__input {
-      border-color: {{ section.settings.foreground_color }};
+      border-color: {{ section.settings.foreground_color }} !important;
     }
 
     .header-search__input::placeholder {
-      color: {{ section.settings.foreground_color | append: "B3"  }};
+      color: {{ section.settings.foreground_color | append: "B3"  }} !important;
     }
 
     .header-search__input:focus {
-      border-color: {{ section.settings.foreground_color }};
-    }
-
-    .header__nav-item:hover {
-      text-decoration-color: {{ section.settings.foreground_color }};
+      border-color: {{ section.settings.foreground_color }} !important;
     }
   {% endif %}
 </style>
@@ -73,41 +72,45 @@
     <nav class="header__nav header__nav--desktop">
       <ul class="list-menu list-menu--horizontal">
         {% for link in section.settings.menu.items %}
-          <li class="list-menu__item">
-            <a href="{{ link.url }}" class="header__nav-item">
-              {{ link.title }}
-              {% if link.items_count > 0 %}
-                <i class="fa-regular fa-chevron-down list-menu__item-caret"></i>
-              {% endif %}
+          <li class="header__nav-item">
+            <a href="{{ link.url }}" class="header__nav-link">
+              <span>
+                {{ link.title }}
+              </span>
             </a>
             {% if link.items_count > 0 %}
-              <div class="list-submenu">
-                <ul class="list-submenu__container">
-                  {% for childlink in link.items %}
-                    <li class="list-menu__item">
-                      <a href="{{ childlink.url }}" class="header__nav-item">
+              <input type="checkbox" id="header__nav-child-{{ forloop.index }}" data-toggle>
+              <label for="header__nav-child-{{ forloop.index }}">
+                <i class="fa-regular fa-angle-down header__nav-item-caret"></i>
+              </label>
+              <ul class="header__nav-submenu">
+                {% for childlink in link.items %}
+                  <li class="header__nav-item">
+                    <a href="{{ childlink.url }}" class="header__nav-link">
+                      <span>
                         {{ childlink.title }}
-                        {% if childlink.items_count > 0 %}
-                          <i class="fa-regular fa-chevron-right list-menu__item-caret"></i>
-                        {% endif %}
-                      </a>
-                      {% if childlink.items_count > 0 %}
-                        <div class="list-submenu">
-                          <ul class="list-submenu__container">
-                            {% for grandchildlink in childlink.items %}
-                              <li class="list-menu__item">
-                                <a href="{{ grandchildlink.url }}" class="header__nav-item">
-                                  {{ grandchildlink.title }}
-                                </a>
-                              </li>
-                            {% endfor %}
-                          </ul>
-                        </div>
-                      {% endif %}
-                    </li>
-                  {% endfor %}
-                </ul>
-              </div>
+                      </span>
+                    </a>
+                    {% if childlink.items_count > 0 %}
+                      <input type="checkbox" id="header__nav-grandchild-{{ forloop.index }}">
+                      <label for="header__nav-grandchild-{{ forloop.index }}">
+                        <i class="fa-regular fa-angle-down header__nav-item-caret"></i>
+                      </label>
+                      <ul class="header__nav-submenu">
+                        {% for grandchildlink in childlink.items %}
+                          <li class="header__nav-item">
+                            <a href="{{ grandchildlink.url }}" class="header__nav-link">
+                              <span>
+                                {{ grandchildlink.title }}
+                              </span>
+                            </a>
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
## Description
This PR refactors the desktop header menu to improve accessibility. The third-level navigation is now rendered under the parent with left indent. Toggling the menus is powered by clicks on chevron and can be dismissed either by click on it again or by clicking outside of the menu

## Preview
**New style preview**
![2023-06-20 15 09 48](https://github.com/booqable/kylie-theme/assets/32096016/d78f0389-d1a7-4263-95b4-0cd387f7cfb6)

**Small height preview**
![2023-06-20 15 28 15](https://github.com/booqable/kylie-theme/assets/32096016/00bbc41d-3e33-4e92-914f-1a932fb2a4c4)

