### PR TITLE
Fix: Carousels not working when `next_product_page` flag is enabled

### DIFF
--- a/assets/carousels.js
+++ b/assets/carousels.js
@@ -114,7 +114,9 @@ const initCarousels = () => {
 const initProductGallery = () => {
   if (!window.location.href.includes("products")) return;
 
-  const gallery = document.querySelector(".product-gallery");
+  const gallery = document.querySelector(".product-gallery--legacy");
+
+  if (!gallery) return;
 
   // Main preview
   const previewInner = gallery.querySelector(".product-gallery__preview-inner");

--- a/assets/index.js
+++ b/assets/index.js
@@ -55,7 +55,9 @@ const initSearch = () => {
 };
 
 const handleSetMobileMenuHeight = () => {
-  if (window.innerWidth > 762) return;
+  const menu = document.querySelector(".header-floating-menu__wrapper");
+
+  if (window.innerWidth > 762 || !menu) return;
 
   let totalHeight = 0;
 
@@ -74,7 +76,6 @@ const handleSetMobileMenuHeight = () => {
   }
 
   const header = document.querySelector(".header__wrapper");
-  const menu = document.querySelector(".header-floating-menu__wrapper");
 
   totalHeight =
     header.getBoundingClientRect().height +

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -61,10 +61,7 @@
   <script src="{{ "lazysizes.min.js" | asset_url }}" defer></script>
   <script src="{{ "index.js" | asset_url }}" defer></script>
   <script src="{{ "menus.js" | asset_url }}" defer></script>
-
-  {% unless enabled_features contains "next_product_page" %}
-    <script src="{{ "carousels.js" | asset_url }}" defer></script>
-  {% endunless %}
+  <script src="{{ "carousels.js" | asset_url }}" defer></script>
 
   {{ content_for_body }}
 

--- a/snippets/product-page-legacy.liquid
+++ b/snippets/product-page-legacy.liquid
@@ -1,7 +1,7 @@
 {{ "product-page-legacy.css" | asset_url | stylesheet_tag }}
 {{ "carousels.css" | asset_url | stylesheet_tag }}
 
-<div class="product-gallery">
+<div class="product-gallery product-gallery--legacy">
   <div class="product-gallery__preview carousel carousel--snap-center">
     <div class="product-gallery__preview-inner carousel__inner infinite-scroll">
       {% for image in product.images %}


### PR DESCRIPTION
This PR resolves issue with not working carousels outside of product page when `next_product_page` flag is enabled in flipper. As a bonus it also resolves the issue with setting mobile menu height if no menu is selected for the header