### PR TITLE
Add `og:site_name` meta tag

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -23,6 +23,9 @@
     <meta property="og:title" content="{{ page_title }}">
     <meta name="twitter:title" content="{{ page_title }}">
   {% endif %}
+
+  <meta property="og:site_name" content="{{ shop.name }}">
+
   {% if page_description != blank %}
     <meta name="description" content="{{ page_description }}">
     <meta property="og:description" content="{{ page_description }}">


### PR DESCRIPTION
Customer complained about google using their domain as site name, instead of a nice readable name. They use `og:site_name` meta tag as a hint when generating site name. To increase the probability of having a nice name we are adding this meta tag here.

Note that it intentionally uses the shop name instead of page_title as it is expected to be consistent across all pages.