### PR TITLE
Dont start css with comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .bqt/
 .DS_Store
+
+# JetBrains editors
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 .bqt/
 .DS_Store
-
-# JetBrains editors
-.idea

--- a/assets/form.css
+++ b/assets/form.css
@@ -1,4 +1,3 @@
-/* Core form styles */
 .form__inner {
   max-width: 725px;
   width: 100%;


### PR DESCRIPTION
Some Safari versions could not load the form css because of a MIME type error.
The form.css file was the only one starting with a comment, I assume thats the issue.

Also found some similar issues, like https://askubuntu.com/questions/639640/files-starting-with-a-comment-have-the-wrong-mime-type