### PR TITLE
Fix: Preview bar overlays header

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -57,13 +57,6 @@
   </head>
   <body>
 
-    {% if settings.primary_color != blank %}
-      {% assign color = settings.primary_color %}
-    {% else %}
-      {% assign color = branding_color %}
-    {% endif %}
-    <bq-date-picker-modal branding-color="{{ color }}"></bq-date-picker-modal>
-
     {% section 'header' %}
 
     <main id="main">
@@ -71,6 +64,13 @@
     </main>
 
     {% section 'footer' %}
+
+    {% if settings.primary_color != blank %}
+      {% assign color = settings.primary_color %}
+    {% else %}
+      {% assign color = branding_color %}
+    {% endif %}
+    <bq-date-picker-modal branding-color="{{ color }}"></bq-date-picker-modal>
 
     <script src="{{ "lazysizes.min.js" | asset_url }}" defer></script>
     <script src="{{ "index.js" | asset_url }}" defer></script>


### PR DESCRIPTION
## Description

Because of the recent update where the `bq-date-picker-modal` was embedded to the layout the style adjustments coming from preview bar was applied to wrong element. To resolve it we are moving the component to the bottom of the body