### PR TITLE
Fix CDN content-type

### DIFF
--- a/assets/sidebar-navigation.css
+++ b/assets/sidebar-navigation.css
@@ -1,4 +1,3 @@
-/* Toggle and expand styles */
 .list-menu__item [id^="sidebar-navigation-menu-child-"],
 .list-menu__item [id^="sidebar-navigation-menu-grandchild-"] {
   display: none;


### PR DESCRIPTION
For reasons unknown, when a CSS file starts with a comment S3 will set its content type to `text/plain` instead of `text/css`. This causes browsers to not apply this CSS.

This PR removes the comment from the CSS file which seems to fix the issue.