### PR TITLE
Add guest checkout URL

### DIFF
--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -60,7 +60,7 @@
 
     <a href="{{ routes.register_url }}" class="account__button account__button--secondary account__divider">{{ section.settings.create_account_label }}</a>
 
-    {%- if shop.allow_guest_checkout && guest_checkout_url -%}
+    {%- if shop.allow_guest_checkout and guest_checkout_url -%}
       <a href="{{ guest_checkout_url }}" class="account__button account__button--minimal">{{ section.settings.continue_as_guest_label }}</a>
     {%- endif -%}
 

--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -60,7 +60,9 @@
 
     <a href="{{ routes.register_url }}" class="account__button account__button--secondary account__divider">{{ section.settings.create_account_label }}</a>
 
-    <a href="" class="account__button account__button--minimal">{{ section.settings.continue_as_guest_label }}</a>
+    {%- if shop.allow_guest_checkout && guest_checkout_url -%}
+      <a href="{{ guest_checkout_url }}" class="account__button account__button--minimal">{{ section.settings.continue_as_guest_label }}</a>
+    {%- endif -%}
 
   {% endform %}
 </div>


### PR DESCRIPTION
This PR adds the proper URL for the "Continue as guest" link on the login page. It also makes sure the link is only visible when guest checkouts are enabled AND the login page is being accessed from the checkout flow.