### PR TITLE
Move flash messages above the forms

### DIFF
--- a/assets/account.css
+++ b/assets/account.css
@@ -164,7 +164,7 @@
 
 .account__alert {
   border-radius: 8px;
-  margin-bottom: 24px;
+  margin-bottom: 12px;
   padding: 12px 16px;
 }
 

--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -9,6 +9,14 @@
     </div>
   {% endif %}
 
+  {%- if alert -%}
+    <div class="account__alert account__alert--danger">{{ alert }}</div>
+  {%- endif -%}
+
+  {%- if notice -%}
+    <div class="account__alert account__alert--info">{{ notice }}</div>
+  {%- endif -%}
+
   {% form 'login' %}
     <div>
       <label for="user_email" class="account-fieldset__label">{{ section.settings.email_label }}</label>
@@ -38,14 +46,6 @@
     <div class="account__divider">
       <a href="{{ routes.new_reset_password_url }}" class="account__link">{{ section.settings.reset_password_label }}</a>
     </div>
-
-    {%- if alert -%}
-      <div class="account__alert account__alert--danger">{{ alert }}</div>
-    {%- endif -%}
-
-    {%- if notice -%}
-      <div class="account__alert account__alert--info">{{ notice }}</div>
-    {%- endif -%}
 
     <div class="account__divider">
       <input

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -9,6 +9,10 @@
     </a>
   </div>
 
+  {%- if alert -%}
+    <div class="account__alert">{{ alert }}</div>
+  {%- endif -%}
+
   {% form 'register' %}
     <div class="{% if form.errors.name %}account-fieldset--error{% endif %}">
       <label for="user_name" class="account-fieldset__label">{{ section.settings.name_label }}</label>
@@ -105,10 +109,6 @@
       </label>
       <div class="account__error-message">{{ form.errors.agreement_accepted }}</div>
     </div>
-
-    {%- if alert -%}
-      <div class="account__alert">{{ alert }}</div>
-    {%- endif -%}
 
     <input
       type="submit"


### PR DESCRIPTION
Flash messages contain important information that you should read before trying to log in, so we're moving them above the form.

# Before
![Screenshot 2024-01-26 at 14 52 33](https://github.com/booqable/kylie-theme/assets/690113/c3a0987c-6228-4c56-8fdf-17c33ac7a2ac)

# After
![Screenshot 2024-01-26 at 14 53 59](https://github.com/booqable/kylie-theme/assets/690113/90742b82-3bf6-493b-8eb3-8f0dd47fe08d)

