### PR TITLE
Add cookie notice settings to theme

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -145,7 +145,7 @@
     "settings": [
       {
         "type": "checkbox",
-        "id": "cookie_notice_activated",
+        "id": "cn_activated",
         "label": "Show cookie notice"
       },
       {
@@ -154,37 +154,37 @@
       },
       {
         "type": "text",
-        "id": "cookie_notice_banner_text",
+        "id": "cn_consent_modal_title",
         "label": "Title",
         "default": "This website uses cookies"
       },
       {
         "type": "contentEditor",
-        "id": "cookie_notice_banner_description",
+        "id": "cn_consent_modal_description",
         "label": "Description",
         "default": "This website collects cookies to deliver you the best possible user experience."
       },
       {
         "type": "text",
-        "id": "cookie_notice_button_accept_all",
+        "id": "cn_consent_modal_accept_all",
         "label": "All cookies button label",
         "default": "Accept all cookies"
       },
       {
         "type": "text",
-        "id": "cookie_notice_button_accept_essential",
+        "id": "cn_consent_modal_accept_essential",
         "label": "Essential cookies button label",
         "default": "Accept only essential cookies"
       },
       {
         "type": "text",
-        "id": "cookie_notice_button_manage_preferences",
+        "id": "cn_consent_modal_manage_preferences",
         "label": "Cookie preferences button label",
         "default": "Manage individual preferences"
       },
       {
         "type": "text",
-        "id": "cookie_notice_link_privacy_policy",
+        "id": "cn_consent_modal_privacy_policy",
         "label": "Privacy policy button label",
         "default": "Privacy policy"
       },
@@ -194,37 +194,37 @@
       },
       {
         "type": "text",
-        "id": "cookie_notice_preferences_title",
+        "id": "cn_preferences_modal_title",
         "label": "Title",
         "default": "Manage cookie preferences"
       },
       {
         "type": "text",
-        "id": "cookie_notice_button_save_preferences",
+        "id": "cn_preferences_modal_save_preferences",
         "label": "Save preferences button label",
         "default": "Accept current selection"
       },
       {
         "type": "text",
-        "id": "cookie_notice_essential_cookies_title",
+        "id": "cn_preferences_modal_essential_cookies_title",
         "label": "Essential cookies title",
         "default": "Strictly Necessary cookies"
       },
       {
         "type": "text",
-        "id": "cookie_notice_essential_cookies_description",
+        "id": "cn_preferences_modal_essential_cookies_description",
         "label": "Essential cookies description",
         "default": "These cookies are essential for the proper functioning of the website and cannot be disabled."
       },
       {
         "type": "text",
-        "id": "cookie_notice_tracking_cookies_title",
+        "id": "cn_preferences_modal_tracking_cookies_title",
         "label": "Tracking cookies title",
         "default": "Performance and Analytics"
       },
       {
         "type": "text",
-        "id": "cookie_notice_tracking_cookies_description",
+        "id": "cn_preferences_modal_tracking_cookies_description",
         "label": "Tracking cookies description",
         "default": "These cookies collect information about how you use our website. All of the data is anonymized and cannot be used to identify you."
       }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -168,19 +168,19 @@
         "type": "text",
         "id": "cn_consent_modal_accept_all",
         "label": "All cookies button label",
-        "default": "Accept all cookies"
+        "default": "Accept all"
       },
       {
         "type": "text",
         "id": "cn_consent_modal_accept_essential",
         "label": "Essential cookies button label",
-        "default": "Accept only essential cookies"
+        "default": "Accept only essential"
       },
       {
         "type": "text",
         "id": "cn_consent_modal_manage_preferences",
         "label": "Cookie preferences button label",
-        "default": "Manage individual preferences"
+        "default": "Manage preferences"
       },
       {
         "type": "text",
@@ -196,13 +196,25 @@
         "type": "text",
         "id": "cn_preferences_modal_title",
         "label": "Title",
-        "default": "Manage cookie preferences"
+        "default": "Manage your cookie preferences"
+      },
+      {
+        "type": "text",
+        "id": "cn_preferences_modal_accept_all",
+        "label": "All cookies button label",
+        "default": "Accept all"
+      },
+      {
+        "type": "text",
+        "id": "cn_preferences_modal_accept_essential",
+        "label": "Essential cookies button label",
+        "default": "Accept only essential"
       },
       {
         "type": "text",
         "id": "cn_preferences_modal_save_preferences",
         "label": "Save preferences button label",
-        "default": "Accept current selection"
+        "default": "Save preferences"
       },
       {
         "type": "text",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -185,7 +185,7 @@
       {
         "type": "text",
         "id": "cn_consent_modal_privacy_policy",
-        "label": "Privacy policy button label",
+        "label": "Privacy policy link label",
         "default": "Privacy policy"
       },
       {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -139,5 +139,95 @@
         "info": "https://vimeo.com/booqable"
       }
     ]
+  },
+  {
+    "name": "Cookie notice",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "cookie_notice_activated",
+        "label": "Show cookie notice"
+      },
+      {
+        "type": "header",
+        "content": "Consent modal"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_banner_text",
+        "label": "Title",
+        "default": "This website uses cookies"
+      },
+      {
+        "type": "contentEditor",
+        "id": "cookie_notice_banner_description",
+        "label": "Description",
+        "default": "This website collects cookies to deliver you the best possible user experience."
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_button_accept_all",
+        "label": "All cookies button label",
+        "default": "Accept all cookies"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_button_accept_essential",
+        "label": "Essential cookies button label",
+        "default": "Accept only essential cookies"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_button_manage_preferences",
+        "label": "Cookie preferences button label",
+        "default": "Manage individual preferences"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_link_privacy_policy",
+        "label": "Privacy policy button label",
+        "default": "Privacy policy"
+      },
+      {
+        "type": "header",
+        "content": "Preferences modal"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_preferences_title",
+        "label": "Title",
+        "default": "Manage cookie preferences"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_button_save_preferences",
+        "label": "Save preferences button label",
+        "default": "Accept current selection"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_essential_cookies_title",
+        "label": "Essential cookies title",
+        "default": "Strictly Necessary cookies"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_essential_cookies_description",
+        "label": "Essential cookies description",
+        "default": "These cookies are essential for the proper functioning of the website and cannot be disabled."
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_tracking_cookies_title",
+        "label": "Tracking cookies title",
+        "default": "Performance and Analytics"
+      },
+      {
+        "type": "text",
+        "id": "cookie_notice_tracking_cookies_description",
+        "label": "Tracking cookies description",
+        "default": "These cookies collect information about how you use our website. All of the data is anonymized and cannot be used to identify you."
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds a new settings section to the Kylie theme. This will be then picked up by the cookie consent modal that will be implemented in a future PR on the main Booqable repo.

The settings will provide us with the texts that will go on the cookie popup plugin: https://playground.cookieconsent.orestbida.com/

Screenshots:
![image](https://github.com/booqable/kylie-theme/assets/1003859/24fa30c9-c601-49e2-b424-23810c0ffa0e)
![image](https://github.com/booqable/kylie-theme/assets/1003859/193fe0c1-8dc8-47ef-a2f6-9eb0c13c71b6)

