### PR TITLE
`Terms & Agreement` modal window

### DIFF
--- a/assets/account.css
+++ b/assets/account.css
@@ -21,7 +21,7 @@
   .account__title {
     font-size: 36px;
     line-height: 44px;
-  }  
+  }
 }
 
 .account__title--centered {
@@ -120,7 +120,7 @@
 }
 
 .account-fieldset--error .account-fieldset__static-label {
-  color: var(--color-danger-dark); 
+  color: var(--color-danger-dark);
 }
 
 .account-fieldset__input{
@@ -157,9 +157,104 @@
   margin-bottom: 24px;
 }
 
-.account__link {
-  color: var(--color-primary);
-  text-decoration: none;
+.account__agreement-opener {
+  color: var(--color-link);
+  cursor: pointer;
+}
+
+.account__agreement-modal {
+  display: block !important;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 20px 10px;
+  backdrop-filter: blur(5px);
+  visibility: hidden;
+  opacity: 0;
+}
+
+.account__agreement-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: 830px;
+  padding: 30px;
+  margin: 0 auto;
+  display: block;
+}
+
+.account__agreement-inner {
+  border: 1px solid var(--color-grey-medium);
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--color-primary-background);
+}
+
+.account__agreement-text {
+  display: block;
+  padding: 16px;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.account__agreement-closer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  text-indent: -9999px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.account__agreement-closer:after,
+.account__agreement-closer:before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 23%;
+  right: 23%;
+  transform: rotate(45deg);
+  height: 2px;
+  background: var(--color-link);
+}
+
+.account__agreement-closer:after {
+  transform: rotate(-45deg);
+}
+
+.account__agreement-buttons {
+  padding-top: 16px;
+  display: block;
+  text-align: center;
+}
+
+.account__agreement-button {
+  max-width: 400px;
+}
+
+[id^='user_agreement_opener']:checked ~ .account__agreement-modal {
+  visibility: visible;
+  opacity: 1;
+}
+
+@media (min-width: 768px) {
+  .account__agreement-modal {
+    padding: 20px 50px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .account__agreement-modal {
+    padding: 50px;
+  }
 }
 
 .account__alert {

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -119,7 +119,7 @@
 
                   <span class="account__agreement-buttons">
                     <label class="account__agreement-button account__button account__button--primary" for="user_agreement_opener">
-                      {{ section.settings.terms_and_agreements_button_label }}
+                      {{ section.settings.terms_and_agreements_accept_button_label }}
                     </label>
                   </span>
                 </span>
@@ -214,7 +214,7 @@
         "label": "Terms and agreements",
         "default": "Terms and agreements"
       }, {
-        "id": "terms_and_agreements_button_label",
+        "id": "terms_and_agreements_accept_button_label",
         "type": "text",
         "label": "Terms and agreements button (Modal window)",
         "default": "Agree"

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -102,10 +102,31 @@
         {% if form.agreement_accepted %}checked{% endif %}>
       <label for="user_agreement_accepted">
         {{ section.settings.i_agree_label }}
-        <a
-          class="account__link"
-          href="https://booqable.com/agreement"
-          target="_blank">{{ section.settings.terms_and_agreements_label }}</a>
+
+        <span class="account__agreement">
+          <input type="checkbox" id="user_agreement_opener" style="display: none">
+          <label for="user_agreement_opener" class="account__agreement-opener">
+            {{ section.settings.terms_and_agreements_label }}
+          </label>
+
+          <span class="account__agreement-modal bq-content rx-content" style="display: none">
+            <span class="account__agreement-content">
+              <span class="account__agreement-inner">
+                <label for="user_agreement_opener" class="account__agreement-closer">X</label>
+
+                <span class="account__agreement-text">
+                  {{- form.agreement_content -}}
+
+                  <span class="account__agreement-buttons">
+                    <label class="account__agreement-button account__button account__button--primary" for="user_agreement_opener">
+                      {{ section.settings.terms_and_agreements_button_label }}
+                    </label>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </span>
+        </span>
       </label>
       <div class="account__error-message">{{ form.errors.agreement_accepted }}</div>
     </div>
@@ -192,6 +213,11 @@
         "type": "text",
         "label": "Terms and agreements",
         "default": "Terms and agreements"
+      }, {
+        "id": "terms_and_agreements_button_label",
+        "type": "text",
+        "label": "Terms and agreements button (Modal window)",
+        "default": "Agree"
       }
     ]
   }


### PR DESCRIPTION
The PR purpose is to introduce Terms & Agreement modal window

Clicked on the "Terms and agreements" link when creating a new customer account led you to a generic Booqable terms page. But should be the actual content of the terms and agreement that company provided.

So in this PR implemented a modal that shows this content, instead of linking to the generic one.

![image (28) (2)](https://github.com/booqable/kylie-theme/assets/40244261/57622168-a66f-40ef-8e69-88a10e5d66ed)
![Screenshot 2024-02-09 at 13 30 55](https://github.com/booqable/kylie-theme/assets/40244261/f338a39e-3f88-4273-8031-e68ce7fc656a)
![Google Chrome_2024-02-13 15-15-00@2x](https://github.com/booqable/kylie-theme/assets/40244261/6b4485c6-6e36-4f8f-8d38-09e5a56b5557)
