### PR TITLE
Kylie theme adjustments for the cookie notice feature

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -150,7 +150,7 @@
       },
       {
         "type": "header",
-        "content": "Consent modal"
+        "content": "Consent popup"
       },
       {
         "type": "text",
@@ -190,7 +190,7 @@
       },
       {
         "type": "header",
-        "content": "Preferences modal"
+        "content": "Preferences popup"
       },
       {
         "type": "text",

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -60,6 +60,9 @@
       <div class="footer__copyright footer__copyright--align-{{ section.settings.align_copyright }}">
         {% if section.settings.show_copyright %}
           &copy; {{ "now" | date: "%Y" }}, {{ shop.name }}
+          {% if settings.cn_activated %}
+            &nbsp;|&nbsp;<a href="{{ routes.privacy_policy_url }}">{{ settings.cn_consent_modal_privacy_policy | escape }}</a>
+          {% endif %}
           {% if show_powered_by %}
             &nbsp;|&nbsp;
           {% endif %}


### PR DESCRIPTION
This PR is a follow up to the demo at showtime. It addresses these things:
- Rename the settings "Consent modal" and "Preferences modal" to "Consent popup" and "Preferences popup" because "popup" is more understandable to our users.
- Make sure the privacy policy page is always visible in the footer. When the link is only in the consent modal, it won't be accessible once the user accepts/denies consent.