### PR TITLE
Add support for rendering app blocks

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -66,18 +66,24 @@
 
 .footer__bottom {
   padding: 32px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .footer__copyright--align-left {
   text-align: left;
+  margin-right: auto;
 }
 
 .footer__copyright--align-center {
   text-align: center;
+  margin: 0 auto;
 }
 
 .footer__copyright--align-right {
   text-align: right;
+  margin-left: auto;
 }
 
 .footer__payment-methods {
@@ -172,9 +178,19 @@
   text-decoration: underline;
 }
 
+.footer-app {
+  display: inline-block;
+}
+
 @media (max-width: 576px) {
+  .footer__bottom {
+    padding: 8px 0 32px 0;
+    flex-direction: column;
+  }
+
   .footer__copyright {
     text-align: center;
+    margin: 0;
   }
 
   .footer__menu {
@@ -191,5 +207,10 @@
 
   .footer__menu > .list-menu__item {
     margin-bottom: 16px;
+  }
+
+  .footer-app {
+    display: initial;
+    margin: 16px 0;
   }
 }

--- a/assets/header.css
+++ b/assets/header.css
@@ -455,6 +455,15 @@
   display: none;
 }
 
+.header__nav--desktop .header-app {
+  margin-left: auto;
+}
+
+.header__nav--mobile .header-app {
+  display: flex;
+  margin: 16px;
+}
+
 @media (max-width: 1100px) {
   .header__nav .list-menu--horizontal > .list-menu__item:not(:last-child) {
     margin-right: 16px;

--- a/assets/header.css
+++ b/assets/header.css
@@ -30,18 +30,6 @@
   background-color: var(--color-primary-background);
 }
 
-.header__wrapper--with-menu {
-  grid-template-columns: max-content 1fr max-content;
-}
-
-.header__wrapper--with-mini-cart {
-  grid-template-columns: 1fr max-content 50px;
-}
-
-.header__wrapper--with-menu.header__wrapper--with-mini-cart {
-  grid-template-columns: max-content 1fr max-content 50px;
-}
-
 .header__link {
   text-decoration: none;
 

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -8,7 +8,7 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when 'app' %}
-        {% include "@app" %}
+        {% include "app" %}
       {% when "socials" %}
         {% include "socials" %}
       {% when "menu" %}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -1,14 +1,14 @@
 {{ "footer.css" | asset_url | stylesheet_tag }}
 
 <!-- Icons -->
-{% assign fa = "paypal,stripe,ideal,alipay" | split: "," %}
+{% assign fa  = "paypal,stripe,ideal,alipay" | split: "," %}
 {% assign svg = "p24,eps,bancontact,giropay" | split: "," %}
+
+{% assign app = section.blocks | where: "type", "app" | first -%}
 
 <div class="footer__content">
   {% for block in section.blocks %}
     {% case block.type %}
-      {% when 'app' %}
-        {% render "app", block: block, section: section %}
       {% when "socials" %}
         {% include "socials" %}
       {% when "menu" %}
@@ -59,6 +59,12 @@
   {% endfor %}
   {% if section.settings.show_copyright or show_powered_by %}
     <div class="footer__bottom">
+      {% if app %}
+        <div class="footer-app">
+          {% render "app", block: app, section: section %}
+        </div>
+      {% endif %}
+
       <div class="footer__copyright footer__copyright--align-{{ section.settings.align_copyright }}">
         {% if section.settings.show_copyright %}
           &copy; {{ "now" | date: "%Y" }}, {{ shop.name }}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -7,6 +7,8 @@
 <div class="footer__content">
   {% for block in section.blocks %}
     {% case block.type %}
+      {% when 'app' %}
+        {% include "app" %}
       {% when "socials" %}
         {% include "socials" %}
       {% when "menu" %}
@@ -227,6 +229,9 @@
           "default": "center"
         }
       ]
+    },
+    {
+      "type": "@app"
     }
   ]
 }

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -8,7 +8,7 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when 'app' %}
-        {% include "app" %}
+        {% include "@app" %}
       {% when "socials" %}
         {% include "socials" %}
       {% when "menu" %}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -8,7 +8,7 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when 'app' %}
-        {% include "app" %}
+        {% render "app", block: block, section: section %}
       {% when "socials" %}
         {% include "socials" %}
       {% when "menu" %}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -221,7 +221,7 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when 'app' %}
-        {% include 'app' %}
+        {% include '@app' %}
     {% endcase %}
   {% endfor %}
 </div>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -221,7 +221,7 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when 'app' %}
-        {% include '@app' %}
+        {% include 'app' %}
     {% endcase %}
   {% endfor %}
 </div>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,6 +1,8 @@
 {{ "header.css" | asset_url | stylesheet_tag }}
 {{ "list-menu.css" | asset_url | stylesheet_tag }}
 
+{% assign app = section.blocks | where: "type", "app" | first -%}
+
 <style>
   {% if section.settings.background_color != blank %}
     .header,
@@ -141,9 +143,17 @@
             {% endif %}
           </li>
         {% endfor %}
+
+        {% if app %}
+          <li class="header-app">
+            {% render 'app', block: app, section: section, size: "desktop" %}
+          </li>
+        {% endif %}
+
       </ul>
     </nav>
   {% endif %}
+
   <div class="header-search">
     <input type="checkbox" id="floating-search">
     <label for="floating-search" class="header-search__trigger">
@@ -161,6 +171,7 @@
       </form>
     </div>
   </div>
+
   {% if show_mini_cart %}
     <div class="header-cart">
       {{ cart_button }}
@@ -213,17 +224,16 @@
               {% endif %}
             </li>
           {% endfor %}
+
+          {% if app %}
+            <li class="header-app">
+              {% render 'app', block: app, section: section, size: "mobile" %}
+            </li>
+          {% endif %}
         </ul>
       </div>
     </div>
   {% endif %}
-
-  {% for block in section.blocks %}
-    {% case block.type %}
-      {% when 'app' %}
-        {% render 'app', block: block, section: section %}
-    {% endcase %}
-  {% endfor %}
 </div>
 
 {% schema %}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -221,7 +221,7 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when 'app' %}
-        {% include 'app' %}
+        {% render 'app', block: block, section: section %}
     {% endcase %}
   {% endfor %}
 </div>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -56,7 +56,20 @@
       --minicart-button-color: {{ section.settings.foreground_color }};
       --minicart-button-hover-color: {{ section.settings.foreground_color }};
     }
+
   {% endif %}
+
+  .header__wrapper--with-menu {
+    grid-template-columns: max-content 1fr max-content{% if section.blocks.size > 0 %} repeat({{ section.blocks.size }}, max-content){% endif %};
+  }
+
+  .header__wrapper--with-mini-cart {
+    grid-template-columns: 1fr max-content 50px{% if section.blocks.size > 0 %} repeat({{ section.blocks.size }}, max-content){% endif %};
+  }
+
+  .header__wrapper--with-menu.header__wrapper--with-mini-cart {
+    grid-template-columns: max-content 1fr max-content 50px{% if section.blocks.size > 0 %} repeat({{ section.blocks.size }}, max-content){% endif %};
+  }
 </style>
 
 <div class="header__wrapper{% if section.settings.menu != blank %} header__wrapper--with-menu{% endif %}{% if show_mini_cart %} header__wrapper--with-mini-cart{% else %} header__wrapper--without-mini-cart{% endif %}">
@@ -204,6 +217,13 @@
       </div>
     </div>
   {% endif %}
+
+  {% for block in section.blocks %}
+    {% case block.type %}
+      {% when 'app' %}
+        {% include 'app' %}
+    {% endcase %}
+  {% endfor %}
 </div>
 
 {% schema %}
@@ -212,6 +232,11 @@
   "tag": "header",
   "class": "header",
   "templates": [],
+  "blocks": [
+    {
+      "type": "@app"
+    }
+  ],
   "settings": [
     {
       "type": "header",

--- a/snippets/app.liquid
+++ b/snippets/app.liquid
@@ -1,1 +1,0 @@
-{{ block.settings.app | render_theme_app: block_settings: block.settings, section_settings: section.settings }}

--- a/snippets/app.liquid
+++ b/snippets/app.liquid
@@ -1,0 +1,1 @@
+{{ block.settings.app | render_theme_app: block_settings: block.settings, section_settings: section.settings }}


### PR DESCRIPTION
This add support for new block type: app which allows rendering theme apps. The first theme app that we are working on is [Google Translate app](https://github.com/booqable/app-google-translate), which adds a dropdown for selecting a language to either the header or the footer section. This block type doesn't defining settings because they are dynamically added from the [app settings file](https://github.com/booqable/app-google-translate/blob/main/config/settings.json).

This shouldn't be merged until we deploy the support for rendering theme apps in the main app.