### PR TITLE
Hide session pages if accounts are disabled

### DIFF
--- a/templates/activate-account.json
+++ b/templates/activate-account.json
@@ -10,6 +10,6 @@
   },
   "order": ["activate-account"],
   "editor_settings": {
-    "visible_when": ["user_authentication_enabled"]
+    "visible_only_when": ["user_authentication_enabled"]
   }
 }

--- a/templates/activate-account.json
+++ b/templates/activate-account.json
@@ -8,5 +8,8 @@
       "settings": {}
     }
   },
-  "order": ["activate-account"]
+  "order": ["activate-account"],
+  "editor_settings": {
+    "visible_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/edit-password.json
+++ b/templates/edit-password.json
@@ -8,5 +8,8 @@
       "settings": {}
     }
   },
-  "order": ["edit-password-form"]
+  "order": ["edit-password-form"],
+  "editor_settings": {
+    "visible_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/edit-password.json
+++ b/templates/edit-password.json
@@ -10,6 +10,6 @@
   },
   "order": ["edit-password-form"],
   "editor_settings": {
-    "visible_when": ["user_authentication_enabled"]
+    "visible_only_when": ["user_authentication_enabled"]
   }
 }

--- a/templates/login.json
+++ b/templates/login.json
@@ -10,6 +10,6 @@
   },
   "order": ["login-form"],
   "editor_settings": {
-    "visible_when": ["user_authentication_enabled"]
+    "visible_only_when": ["user_authentication_enabled"]
   }
 }

--- a/templates/login.json
+++ b/templates/login.json
@@ -8,5 +8,8 @@
       "settings": {}
     }
   },
-  "order": ["login-form"]
+  "order": ["login-form"],
+  "editor_settings": {
+    "visible_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/register.json
+++ b/templates/register.json
@@ -8,5 +8,8 @@
       "settings": {}
     }
   },
-  "order": ["register-form"]
+  "order": ["register-form"],
+  "editor_settings": {
+    "visible_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/register.json
+++ b/templates/register.json
@@ -10,6 +10,6 @@
   },
   "order": ["register-form"],
   "editor_settings": {
-    "visible_when": ["user_authentication_enabled"]
+    "visible_only_when": ["user_authentication_enabled"]
   }
 }

--- a/templates/reset-password.json
+++ b/templates/reset-password.json
@@ -8,5 +8,8 @@
       "settings": {}
     }
   },
-  "order": ["reset-password-form"]
+  "order": ["reset-password-form"],
+  "editor_settings": {
+    "visible_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/reset-password.json
+++ b/templates/reset-password.json
@@ -10,6 +10,6 @@
   },
   "order": ["reset-password-form"],
   "editor_settings": {
-    "visible_when": ["user_authentication_enabled"]
+    "visible_only_when": ["user_authentication_enabled"]
   }
 }


### PR DESCRIPTION
When accounts are disabled, account related templates throw errors in the theme editor. This PR makes sure those templates are hidden depending on the account settings.