### PR TITLE
Remove textarea description from Cookie Notice settings

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -159,7 +159,7 @@
         "default": "This website uses cookies"
       },
       {
-        "type": "textarea",
+        "type": "text",
         "id": "cookie_notice_consent_modal_description",
         "label": "Description",
         "default": "This website collects cookies to deliver you the best possible user experience."


### PR DESCRIPTION
The text area is breaking the JS code when there are newline characters in there.