### PR TITLE
Allow HTML in image banner text

### DIFF
--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -89,7 +89,7 @@
         {% when "heading" %}
           <h1 id="{{ block.id }}" class="image-banner__title image-banner__title--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</h1>
         {% when "text" %}
-          <p id="{{ block.id }}" class="image-banner__text image-banner__text--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</p>
+          <p id="{{ block.id }}" class="image-banner__text image-banner__text--size-{{ block.settings.size }}">{{ block.settings.text }}</p>
         {% when "button" %}
           <div class="image-banner__button-container image-banner__button-container--align-{{ section.settings.content_align }}">
             <a id="{{ block.id }}" class="bq-button bq-button--size-{{ block.settings.size }} {% if block.settings.use_solid_button %}bq-button--solid{% endif %}" href="{{ block.settings.url }}" {% if block.settings.use_new_tab %}target="_blank"{% endif %}>


### PR DESCRIPTION
A customer is trying to use `{{ page.content }}` within Text block of an Image Banner section to render content of a custom page within it. It was not working because we escape HTML in it. This PR remove the HTML escaping. We allow it in other text fields anyway.

## Before

![Screenshot 2024-04-22 at 16 51 54](https://github.com/booqable/kylie-theme/assets/690113/da3be16b-cb14-44a5-aefa-ea737860879c)

## After
![Screenshot 2024-04-22 at 16 59 03](https://github.com/booqable/kylie-theme/assets/690113/71663b42-2d24-4f15-bb13-e370f978d30a)

