### PR TITLE
Alignment Payment methods icons in Footer

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -91,6 +91,7 @@
   flex-flow: row wrap;
   align-items: center;
 
+  margin: 0 -4px;
   padding: 15px 0;
 }
 
@@ -115,10 +116,14 @@
 .footer__payment-methods svg {
   max-height: 32px;
   max-width: 75px;
+  width: 100%;
 }
 
-.footer__payment-methods i:not(:last-child) {
-  margin-right: 8px;
+.footer__payment-methods span[title],
+.footer__payment-methods i {
+  margin: 0 4px 4px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .footer__social {

--- a/snippets/bancontact-icon.liquid
+++ b/snippets/bancontact-icon.liquid
@@ -4,10 +4,7 @@
 		id="Layer_1"
 		xmlns="http://www.w3.org/2000/svg"
 		xmlns:xlink="http://www.w3.org/1999/xlink"
-		x="0px"
-		y="0px"
 		viewBox="0 0 326.1 230.5"
-		style="enable-background: new 0 0 326.1 230.5"
 		xml:space="preserve"
 	>
 		<style type="text/css">

--- a/snippets/eps-icon.liquid
+++ b/snippets/eps-icon.liquid
@@ -4,10 +4,6 @@
     id="Layer_1"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    x="0px"
-    y="0px"
-    width="889px"
-    height="577px"
     viewBox="0 0 889 577"
     enable-background="new 0 0 889 577"
     xml:space="preserve"
@@ -93,7 +89,7 @@
       <polygon
         clip-path="url(#SVGID_2_)"
         fill="var(--color-primary-foreground)"
-        points="614.455,487 617.528,509.934 628.642,487 635.439,487 620.188,516 
+        points="614.455,487 617.528,509.934 628.642,487 635.439,487 620.188,516
       613.036,516 610.14,496.869 605.469,506.373 600.386,516 593.292,516 588.148,487 595.006,487 598.021,509.934 609.193,487 	"
       />
       <path

--- a/snippets/giropay-icon.liquid
+++ b/snippets/giropay-icon.liquid
@@ -3,8 +3,6 @@
     xmlns:svg="http://www.w3.org/2000/svg"
     xmlns="http://www.w3.org/2000/svg"
     version="1.0"
-    width="921.25983"
-    height="425.19684"
     viewBox="0 0 921.25983 425.19684"
     id="svg2226"
   >

--- a/snippets/p24-icon.liquid
+++ b/snippets/p24-icon.liquid
@@ -2,11 +2,7 @@
   <svg
     xmlns="http://www.w3.org/2000/svg"
     version="1.1"
-    x="0"
-    y="0"
     viewBox="0 0 1366 768"
-    width="1366"
-    height="768"
     xml:space="preserve"
   >
     <g transform="matrix(7.5271 0 0 7.24 -4467.715 -2406.117)">


### PR DESCRIPTION
In Website Builder, the Giropay icon in Footer is a bit mis-aligned.

It's also the only item that's a `span`, the others are `i`s

<img width="1222" alt="image" src="https://github.com/booqable/kylie-theme/assets/40244261/d850f37f-4e4b-46e4-b1d6-b1621854bc35">


So the PR's purpose is to align icons vertically and spaces between them

After:

![Arc_2024-04-26 17-27-38@2x](https://github.com/booqable/kylie-theme/assets/40244261/3f9e5286-c1ed-449e-955c-32acceb8f022)
![Arc_2024-04-26 17-26-06@2x](https://github.com/booqable/kylie-theme/assets/40244261/c852d6c4-5af6-4222-8462-286f4fff1d04)
