### PR TITLE
Fix overflow when the logo is too big

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -475,11 +475,11 @@
 }
 
 @media (max-width: 762px) {
-  .header__wrapper--with-menu, .header__wrapper--with-mini-cart {
+  .header .header__wrapper--with-menu, .header .header__wrapper--with-mini-cart {
     grid-template-columns: 1fr repeat(2, 50px);
   }
-  
-  .header__wrapper--with-menu.header__wrapper--with-mini-cart {
+
+  .header .header__wrapper--with-menu.header__wrapper--with-mini-cart {
     grid-template-columns: 1fr repeat(3, 50px);
   }
 
@@ -562,5 +562,6 @@
 
   .header__image-logo {
     max-width: 100%;
+    padding-right: 16px;
   }
 }


### PR DESCRIPTION
The purpose of this PR is to fix the logo issue reported by the customer when on mobile devices the logo is too big and there is overflow on the right side.

Before:
<img width="111" alt="Screenshot 2024-05-14 at 14 13 37" src="https://github.com/booqable/kylie-theme/assets/40244261/8fd96b3a-cb37-4478-9fef-b46e9e581eec">
![Arc_2024-05-17 13-24-55@2x](https://github.com/booqable/kylie-theme/assets/40244261/25a71173-1e82-4186-b3c1-4de9a66c9818)


After:
![Arc_2024-05-17 13-24-36@2x](https://github.com/booqable/kylie-theme/assets/40244261/17f7d35d-6b16-47c4-88cb-4c8b3a76b0ee)


