### PR TITLE
Mark `header` and `footer` as layout section

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -89,6 +89,7 @@
   "tag": "footer",
   "class": "footer",
   "templates": [],
+  "layout": true,
   "settings": [
     {
       "type": "header",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -242,6 +242,7 @@
   "tag": "header",
   "class": "header",
   "templates": [],
+  "layout": true,
   "blocks": [
     {
       "type": "@app"


### PR DESCRIPTION
## Description

The following changes are required to omit the layout sections from injecting the "Add section" HTML snippet