### PR TITLE
Fix metadata and apply on all layouts

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -8,14 +8,22 @@
   <script src="https://kit.fontawesome.com/ff3b3de2b5.js" crossorigin="anonymous"></script>
   {{ content_for_checkout_header }}
 
-  {% include 'fonts' %}
-  {% include 'color-palette-styles' %}
+  {% render 'fonts', settings: settings %}
+  {% render 'color-palette-styles', settings: settings %}
 
-  {% if shop.favicon_url %}
-    <link rel="shortcut icon" href="{{ shop.favicon_url }}" />
-  {% endif %}
+  {% render 'page-metadata',
+    canonical_url: canonical_url,
+    page_title: page_title,
+    page_description: page_description,
+    page_meta_image_url: page_meta_image_url,
+    page_meta_image_alt: page_meta_image_alt,
+    product: product,
+    shop: shop,
+    locale: locale
+  %}
 </head>
 <body>
+  yooooo
   {{ content_for_layout }}
 
   {{ content_for_body }}

--- a/layout/minimal.liquid
+++ b/layout/minimal.liquid
@@ -21,35 +21,22 @@
     {{ content_for_header }}
   {% endif %}
 
-  {% include 'fonts' %}
-  {% include 'color-palette-styles' %}
+  {% render 'fonts', settings: settings %}
+  {% render 'color-palette-styles', settings: settings %}
 
-  {% if shop.favicon_url %}
-    <link rel="shortcut icon" href="{{ shop.favicon_url }}" />
-  {% endif %}
-
-  {% if page_title == blank %}
-    <title>{{ shop.name }}</title>
-    <meta property="og:title" content="{{ shop.name }}">
-    <meta name="twitter:title" content="{{ shop.name }}">
-  {% else %}
-    <title>{{ page_title }}</title>
-    <meta property="og:title" content="{{ page_title }}">
-    <meta name="twitter:title" content="{{ page_title }}">
-  {% endif %}
-
-  <meta property="og:site_name" content="{{ shop.name }}">
-
-  {% if page_description != blank %}
-    <meta name="description" content="{{ page_description }}">
-    <meta property="og:description" content="{{ page_description }}">
-    <meta name="twitter:description" content="{{ page_description }}">
-  {% endif %}
-  <meta name="twitter:card" content="summary">
-  <meta property="og:locale" content="{{ locale }}">
-
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ canonical_url }}">
+  {%- unless section_preview -%}
+    {% render 'page-metadata',
+      canonical_url: canonical_url,
+      page_title: page_title,
+      page_description: page_description,
+      shop: shop
+      page_meta_image_url: page_meta_image_url,
+      page_meta_image_alt: page_meta_image_alt,
+      product: product,
+      shop: shop,
+      locale: locale
+    %}
+  {%- endunless -%}
 </head>
 <body>
 

--- a/layout/session.liquid
+++ b/layout/session.liquid
@@ -12,35 +12,19 @@
   <script src="https://kit.fontawesome.com/ff3b3de2b5.js" crossorigin="anonymous"></script>
   {{ content_for_header }}
 
-  {% include 'fonts' %}
-  {% include 'color-palette-styles' %}
+  {% render 'fonts', settings: settings %}
+  {% render 'color-palette-styles', settings: settings %}
 
-  {% if shop.favicon_url %}
-    <link rel="shortcut icon" href="{{ shop.favicon_url }}" />
-  {% endif %}
-
-  {% if page_title == blank %}
-    <title>{{ shop.name }}</title>
-    <meta property="og:title" content="{{ shop.name }}">
-    <meta name="twitter:title" content="{{ shop.name }}">
-  {% else %}
-    <title>{{ page_title }}</title>
-    <meta property="og:title" content="{{ page_title }}">
-    <meta name="twitter:title" content="{{ page_title }}">
-  {% endif %}
-
-  <meta property="og:site_name" content="{{ shop.name }}">
-
-  {% if page_description != blank %}
-    <meta name="description" content="{{ page_description }}">
-    <meta property="og:description" content="{{ page_description }}">
-    <meta name="twitter:description" content="{{ page_description }}">
-  {% endif %}
-  <meta name="twitter:card" content="summary">
-  <meta property="og:locale" content="{{ locale }}">
-
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ canonical_url }}">
+  {% render 'page-metadata',
+    canonical_url: canonical_url,
+    page_title: page_title,
+    page_description: page_description,
+    page_meta_image_url: page_meta_image_url,
+    page_meta_image_alt: page_meta_image_alt,
+    product: product,
+    shop: shop,
+    locale: locale
+  %}
 </head>
 <body>
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -15,12 +15,14 @@
     {% render 'color-palette-styles', settings: settings %}
 
     {% render 'page-metadata',
+      canonical_url: canonical_url,
       page_title: page_title,
       page_description: page_description,
       page_meta_image_url: page_meta_image_url,
       page_meta_image_alt: page_meta_image_alt,
       product: product,
-      shop: shop
+      shop: shop,
+      locale: locale
     %}
   </head>
   <body>

--- a/snippets/page-metadata.liquid
+++ b/snippets/page-metadata.liquid
@@ -1,12 +1,6 @@
-{% if page_title == blank %}
-  <title>{{ shop.name }}</title>
-  <meta property="og:title" content="{{ shop.name }}">
-  <meta name="twitter:title" content="{{ shop.name }}">
-{% else %}
-  <title>{{ page_title }}</title>
-  <meta property="og:title" content="{{ page_title }}">
-  <meta name="twitter:title" content="{{ page_title }}">
-{% endif %}
+<title>{{ page_title }}</title>
+<meta property="og:title" content="{{ page_title }}">
+<meta name="twitter:title" content="{{ page_title }}">
 
 <meta property="og:site_name" content="{{ shop.name }}">
 
@@ -28,7 +22,7 @@
   <meta property="og:url" content="{{ canonical_url }}">
 {% else %}
   <meta property="og:type" content="product">
-  <meta property="og:url" content="{{ product.url }}">
+  <meta property="og:url" content="{{ canonical_url | append: product.url }}">
 {% endif %}
 
 {% if page_meta_image_url != blank %}


### PR DESCRIPTION
## Why

Layouts were not rendering the same metadata props and prod themes are missing values

- [x] Fixed missing props `locale` and `canonical_url` for rendering page metadata
- [x] Fixed `og:url` for product pages not being the absolute url
- [x] Render page metadata for all layouts
- [x] Always use `page_title` from drop

From live [client site](https://rinkratrentals.com/):

<img width="389" alt="Screenshot 2024-08-23 at 13 24 40" src="https://github.com/user-attachments/assets/9ce899a8-2860-4204-a37d-1b92973ca6e5">

<img width="303" alt="Screenshot 2024-08-23 at 13 25 07" src="https://github.com/user-attachments/assets/7d14a467-09ee-4fd7-862a-81ea76b6fdb3">

After:

<img width="860" alt="Screenshot 2024-08-23 at 13 27 48" src="https://github.com/user-attachments/assets/e2fd5569-2812-4fb7-ab61-0e2f51c0f8f1">
