### PR TITLE
Fix: Translations are ignored for the cart title

### DIFF
--- a/sections/cart.liquid
+++ b/sections/cart.liquid
@@ -36,7 +36,6 @@
       "type": "text",
       "id": "title",
       "label": "Title",
-      "default": "Cart",
       "info": "Leave blank to use title defined in the translations"
     },
     {


### PR DESCRIPTION
## Description

One of the existing clients reported that the translations are not working for the cart page title while using the embeddable components in the Shopify. This was happening because the title has the default value and always fulfils the following code check
```liquid
{% if section.settings.title != blank %}
  {{ section.settings.title }}
{% else %}
...
```

This PR resolves the issue, by removing the default value in the section schema

## Links

Resolves GUA-1055 [link](https://linear.app/booqable/issue/GUA-1055/missing-translation)