### PR TITLE
Load focal images after the window has been fully loaded

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -110,9 +110,10 @@ const handleScroll = () => {
 document.addEventListener("DOMContentLoaded", () => {
   // Initializers
   initSearch();
-  initFocalImages();
   handleSetMobileMenuHeight();
 });
+
+window.addEventListener("load", initFocalImages);
 
 window.addEventListener("resize", () => {
   handleSetMobileMenuHeight();


### PR DESCRIPTION
The customers who use the Kylie theme have been experiencing an issue with loading product images that have `.focal-image` class with opacity: 0 property but for some reason, on mobile the `initFocalImages` function is not fired properly and images are still transparent because they haven’t actually loaded when the script tries to do focal-point calculations.

The PR's goal is to solve the issue by using a new listener to trigger the function `window.addEventListener("load", initFocalImages)` instead of `document.addEventListener("DOMContentLoaded", initFocalImages())`