### PR TITLE
Fix `Liquid error: internal` if the product price and period are not available

### DIFF
--- a/snippets/products-inner.liquid
+++ b/snippets/products-inner.liquid
@@ -26,8 +26,10 @@
       {%- if product.excerpt != blank and section.settings.show_excerpt -%}
         <div class="product__description">{{- product.excerpt -}}</div>
       {%- endif -%}
-      {{ product | product_price_label }}
-      {{ product | product_price }}
+      {%- if product | product_price_label != blank and product | product_price != blank -%}
+        {{ product | product_price_label }}
+        {{ product | product_price }}
+      {%- endif -%}
     </div>
   {% else %}
     <div class="product-cleanstate {% if section.settings.use_carousel %}carousel__item{% endif %}">


### PR DESCRIPTION
The customer complained that some products showed `Liquid error: internal` on their website.
Therefore, this PR's purpose is to add a check if the product price and period are available before displaying them


https://booqable.slack.com/archives/CE98ZB8E6/p1745415106608849
