### PR TITLE
Can't click on Date picker on mobile phone

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -31,9 +31,9 @@ const initFocalImages = () => {
 };
 
 const initSearch = () => {
-  const search = document.querySelector("#search");
+  const searchForm = document.querySelector("#search");
   const url = new URL(window.location.href);
-  const input = search.querySelector("input");
+  const input = searchForm.querySelector("input");
 
   if (!!url.searchParams.get("q")) {
     input.value = url.searchParams.get("q");
@@ -51,7 +51,7 @@ const initSearch = () => {
     window.location.href = url.href;
   };
 
-  search.addEventListener("submit", handleSearchSubmit);
+  searchForm.addEventListener("submit", handleSearchSubmit);
 };
 
 const handleSetMobileMenuHeight = () => {


### PR DESCRIPTION
Error found in Browser Stack: `SyntaxError: Can't create duplicate variable: 'schema Org Type Domain'`

It looks like safari browser has some problems when constants and id are the same name.
[StackOverflow](https://stackoverflow.com/questions/40091136/cant-create-duplicate-variable-that-shadows-a-global-property)

We are going to change the name of the constant `search` to not be same as the `id` of the query selector.
This may fix the issue.

Tries to Fix [Can't click on Date picker on mobile phone](https://linear.app/booqable/issue/GUA-1257/cant-click-on-date-picker-on-mobile-phone)