### PR TITLE
Fix product price display condition

### DIFF
--- a/snippets/products-inner.liquid
+++ b/snippets/products-inner.liquid
@@ -26,7 +26,7 @@
       {%- if product.excerpt != blank and section.settings.show_excerpt -%}
         <div class="product__description">{{- product.excerpt -}}</div>
       {%- endif -%}
-      {%- if product | product_price_label != blank and product | product_price != blank -%}
+      {%- if product | product_price_label and product | product_price -%}
         {{ product | product_price_label }}
         {{ product | product_price }}
       {%- endif -%}


### PR DESCRIPTION
This PR includes a minor update to the conditional logic in the `snippets/products-inner.liquid` file to avoid getting `Liquid error: comparison of Integer with nil`

* Simplified the conditional check for displaying product price and label by removing redundant `!= blank` checks, as the presence of the values themselves is sufficient for evaluation