### PR TITLE
Add `product description placement` option

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -108,6 +108,10 @@ bq-product-availability-calendar {
   position: relative;
 }
 
+.product-info__title + .product-description {
+  margin: 32px 0 40px;
+}
+
 .product-description__label {
   font-size: 20px;
   line-height: 28px;

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -13,6 +13,26 @@
   "settings": [
     {
       "type": "header",
+      "content": "General"
+    },
+    {
+      "type": "select",
+      "id": "description_placement",
+      "label": "Product description placement",
+      "options": [
+        {
+          "value": "top",
+          "label": "Top"
+        },
+        {
+          "value": "bottom",
+          "label": "Bottom"
+        }
+      ],
+      "default": "bottom"
+    },
+    {
+      "type": "header",
       "content": "Translations"
     },
     {

--- a/snippets/product-page.liquid
+++ b/snippets/product-page.liquid
@@ -1,7 +1,7 @@
 {{ "product-page.css" | asset_url | stylesheet_tag }}
 
 <div class="product-gallery">
-  {{ product | product_gallery: 
+  {{ product | product_gallery:
     enable_thumbnails: true,
     enable_controls: true,
     infinite_scroll: true
@@ -10,7 +10,16 @@
 <div class="product-details">
   <div class="product-info">
     <h1 class="product-info__title">{{ product.name }}</h1>
-    
+
+    {% if product.description != blank and section.settings.description_placement == "top" %}
+      <div class="product-description">
+        <p class="product-description__label">{{ section.settings.description_label }}</p>
+        <div class="product-description__content-container bq-content rx-content">
+          {{ product.description }}
+        </div>
+      </div>
+    {% endif %}
+
     <div class="product-button">
       {% if product.variants.size > 1 %}
         <p class="product-info__label">{{ section.settings.variation_label }}</p>
@@ -26,7 +35,7 @@
       {{ product | product_button }}
     </div>
   </div>
-  {% if product.description != blank %}
+  {% if product.description != blank and section.settings.description_placement == "bottom" %}
     <div class="product-description">
       <p class="product-description__label">{{ section.settings.description_label }}</p>
       <div class="product-description__content-container bq-content rx-content">

--- a/templates/aero/product.json
+++ b/templates/aero/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/arc/product.json
+++ b/templates/arc/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/float/product.json
+++ b/templates/float/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/myst/product.json
+++ b/templates/myst/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/product.json
+++ b/templates/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "variation_label": "Variation",
+        "description_placement": "bottom",
         "description_label": "Description"
       },
       "disabled": null

--- a/templates/reverb/product.json
+++ b/templates/reverb/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/summit/product.json
+++ b/templates/summit/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/torque/product.json
+++ b/templates/torque/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/traverse/product.json
+++ b/templates/traverse/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/velo/product.json
+++ b/templates/velo/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null

--- a/templates/wayfarer/product.json
+++ b/templates/wayfarer/product.json
@@ -7,6 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
+        "description_placement": "bottom",
         "variation_label": "Variation"
       },
       "disabled": null


### PR DESCRIPTION
We want to add an option to position the product description above or below the `Add to cart` section like we have in other themes. This was requested by a customer with a really large bundle.

![image (152)](https://github.com/user-attachments/assets/9b62963a-1d0f-4abd-b2a1-cf3aeb6e29e4)


This PR introduces a new feature allowing users to customize the placement of product descriptions on the product page, along with styling updates to enhance the visual layout. The most important changes include adding a `description_placement` setting, updating the logic for rendering product descriptions based on this setting, and modifying the styles for better spacing.

### Feature Addition: Product Description Placement Customization
* [`sections/product-page.liquid`](diffhunk://#diff-0d1405a5e9bee61019d4779f31849427370acd1074ff82785596a003235d0611R14-R33): Added a new `description_placement` setting with options for "top" or "bottom" placement of the product description.
* [`snippets/product-page.liquid`](diffhunk://#diff-4a2e576aa163887a57bb90643623c44d39818e97467e0375d5d36dbc40796698R14-R22): Updated logic to conditionally render product descriptions at the top or bottom of the page based on the `description_placement` setting. [[1]](diffhunk://#diff-4a2e576aa163887a57bb90643623c44d39818e97467e0375d5d36dbc40796698R14-R22) [[2]](diffhunk://#diff-4a2e576aa163887a57bb90643623c44d39818e97467e0375d5d36dbc40796698L29-R38)

### Styling Updates
* [`assets/product-page.css`](diffhunk://#diff-2a5e31d7b238794ec16fb788302c5e9fa133bc5ea654cfb6a4ac2dc4dbe505c4R111-R114): Added spacing adjustments for the `.product-description` element to improve visual layout.

### Default Setting Updates Across Templates
* Multiple files (`templates/aero/product.json`, `templates/arc/product.json`, `templates/float/product.json`, etc.): Set the default value of `description_placement` to "bottom" in various product templates to ensure consistent behavior. [[1]](diffhunk://#diff-8417bf785fa0f044bdda0f1be65658f407f53eb958a88067c4e54990ab1cd1dbR10) [[2]](diffhunk://#diff-f91ef46c984bc918504eecddd9b811482670851961bc70d6813941d6e28a7da4R10) [[3]](diffhunk://#diff-4f9ae8b80562a2b279ef2493fe862baa964c9f4978ceaf5795ed45a596c271ddR10)


### Before:

![Arc 2025-06-23 12 56 01](https://github.com/user-attachments/assets/e639bedb-0ca4-4d3e-b1dc-14ab72f87451)


### After:

![Arc 2025-06-23 12 53 16](https://github.com/user-attachments/assets/4e2f6e41-0707-493d-9f7c-57dbffdbd40b)
![Arc 2025-06-23 12 52 53](https://github.com/user-attachments/assets/2b3b0093-962b-4e06-8724-e28ce2d7a476)

