### PR TITLE
Variation label not translatable

### DIFF
--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -37,12 +37,6 @@
     },
     {
       "type": "text",
-      "id": "variation_label",
-      "label": "Variations label",
-      "default": "Variation"
-    },
-    {
-      "type": "text",
       "id": "description_label",
       "label": "Description label",
       "default": "Description"

--- a/snippets/product-page.liquid
+++ b/snippets/product-page.liquid
@@ -1,5 +1,7 @@
 {{ "product-page.css" | asset_url | stylesheet_tag }}
 
+{%- assign variation_label               = 'store.variant' | user_t | default: section.settings.variation_label -%}
+
 <div class="product-gallery">
   {{ product | product_gallery:
     enable_thumbnails: true,
@@ -22,7 +24,7 @@
 
     <div class="product-button">
       {% if product.variants.size > 1 %}
-        <p class="product-info__label">{{ section.settings.variation_label }}</p>
+        <p class="product-info__label">{{- variation_label -}}</p>
       {% endif %}
       {{ product | bundle_items }}
       {{ product | product_variations_select }}

--- a/templates/aero/product.json
+++ b/templates/aero/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/arc/product.json
+++ b/templates/arc/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/float/product.json
+++ b/templates/float/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/myst/product.json
+++ b/templates/myst/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/product.json
+++ b/templates/product.json
@@ -6,7 +6,6 @@
       "blocks": {},
       "block_order": [],
       "settings": {
-        "variation_label": "Variation",
         "description_placement": "bottom",
         "description_label": "Description"
       },

--- a/templates/reverb/product.json
+++ b/templates/reverb/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/summit/product.json
+++ b/templates/summit/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/torque/product.json
+++ b/templates/torque/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/traverse/product.json
+++ b/templates/traverse/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/velo/product.json
+++ b/templates/velo/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },

--- a/templates/wayfarer/product.json
+++ b/templates/wayfarer/product.json
@@ -8,7 +8,6 @@
       "settings": {
         "description_label": "Description",
         "description_placement": "bottom",
-        "variation_label": "Variation"
       },
       "disabled": null
     },


### PR DESCRIPTION
## Why

We are removing the option to change the `variant_label`, it will be handled by user translations

## Link

[Variation label not translatable](https://linear.app/booqable/issue/SC-1698/variation-label-not-translatable)