### PR TITLE
Add cover/contain options to product and collection cards

### DIFF
--- a/assets/collections.css
+++ b/assets/collections.css
@@ -90,7 +90,16 @@
   height: 400px;
 
   border-radius: var(--border-radius-sm);
+}
 
+.collections__list--overlay .collection:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
   background-color: var(--color-image-placeholder);
 }
 
@@ -100,7 +109,7 @@
   width: 100%;
   height: 100%;
 
-  object-fit: cover;
+  object-fit: var(--object-fit, cover);
 }
 
 .collection__name {
@@ -114,17 +123,21 @@
   margin: 0;
   padding: 24px 0 16px;
 
+  color: var(--color-primary-foreground);
+
+  position: relative;
+  z-index: 1;
+
+  text-align: center;
+}
+
+.collections__list--overlay .collection__name {
   color: var(--color-white);
   background-image: linear-gradient(
     to top,
     rgba(0, 0, 0, 0.6),
     rgba(0, 0, 0, 0)
   );
-
-  position: relative;
-  z-index: 1;
-
-  text-align: center;
 }
 
 .collection-cleanstate {

--- a/assets/product.css
+++ b/assets/product.css
@@ -21,7 +21,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-
+  overflow: clip;
   width: 100%;
   height: 240px;
 
@@ -46,11 +46,10 @@
 
 .product .product__image:not(.focal-image) {
   display: block;
-
-  max-width: 100%;
-  max-height: 100%;
-
   margin: 0 auto;
+  width: 100%;
+  height: 100%;
+  object-fit: var(--object-fit, contain);
 }
 
 .product .product__name {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -74,10 +74,56 @@
     "name": "Images",
     "settings": [
       {
+        "type": "header",
+        "content": "Product card image settings"
+      },
+      {
+        "type": "select",
+        "id": "product_card_image_fit",
+        "label": "Image fit",
+        "options": [
+          {
+            "value": "cover",
+            "label": "Cover"
+          },
+          {
+            "value": "contain",
+            "label": "Contain"
+          }
+        ],
+        "default": "contain"
+      },
+      {
         "type": "checkbox",
         "id": "use_focal_images",
         "label": "Use focal images",
-        "info": "Display point focused images for products instead of full sized"
+        "info": "Display point focused image instead of full sized. Overwrites the 'Image fit' values."
+      },
+      {
+        "type": "header",
+        "content": "Collection image settings"
+      },
+      {
+        "type": "select",
+        "id": "collection_card_image_fit",
+        "label": "Image fit",
+        "options": [
+          {
+            "value": "cover",
+            "label": "Cover"
+          },
+          {
+            "value": "contain",
+            "label": "Contain"
+          }
+        ],
+        "default": "cover"
+      },
+      {
+        "type": "checkbox",
+        "id": "collection_card_image_overlay",
+        "label": "Show image overlay",
+        "default": true
       }
     ]
   },

--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -11,6 +11,25 @@
 {% if canonical_url contains "/1?" or canonical_url contains "/1#" %}
   {% include "collection-page-preview" %}
 {% else %}
+  {% assign card_image_fit = settings.product_card_image_fit %}
+
+  {% comment %} CSS variables start {% endcomment %}
+  {% capture image_variables %}
+    {% case card_image_fit %}
+      {% when 'cover' %}
+        --object-fit: cover;
+      {% when 'contain' %}
+        --object-fit: contain;
+    {% endcase %}
+  {% endcapture %}
+
+  {% if settings.use_focal_images %}
+    {% capture image_variables %}
+      --object-fit: cover;
+    {% endcapture %}
+  {% endif %}
+  {% comment %} CSS variables end {% endcomment %}
+
   <div class="collection-page__wrapper {% if section.blocks.size > 0 %}collection-page__wrapper--with-sidebar{% endif %}">
     <div class="collection-page__sidebar-navigation">
       {% if section.blocks.size > 0 %}
@@ -31,7 +50,7 @@
       {% if collection.items_count > 0 %}
         {% assign paginate_object = collection.items %}
         {% paginate paginate_object %}
-          <div class="collection-page__items">
+          <div class="collection-page__items"{% if card_image_fit != blank %} style="{{- image_variables | escape -}}"{% endif %}>
             {% for item in paginate_object %}
               {% assign image = item.images.first %}
               {% if settings.use_focal_images %}

--- a/sections/collections.liquid
+++ b/sections/collections.liquid
@@ -1,5 +1,18 @@
 {{ "collections.css" | asset_url | stylesheet_tag }}
 
+{%- assign image_fit = settings.collection_card_image_fit -%}
+
+{% comment %} CSS variables start {% endcomment %}
+{%- capture image_variables -%}
+  {%- case image_fit -%}
+    {%- when 'cover' -%}
+      --object-fit: cover;
+    {%- when 'contain' -%}
+      --object-fit: contain;
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
+
 {% if section.settings.title %}
   <h2 class="collections__title collections__title--size-{{ section.settings.title_size }}">{{ section.settings.title }}</h2>
 {% endif %}
@@ -9,7 +22,7 @@
     <i class="fa-regular fa-chevron-right"></i>
   </a>
 {% endif %}
-<div class="collections__list">
+<div class="collections__list{% if settings.collection_card_image_overlay %} collections__list--overlay{% endif %}"{% if image_fit != blank %} style="{{- image_variables | escape -}}"{%- endif -%}>
   {% if section.blocks.size >= 1 and section.blocks.first.settings.collection != blank %}
     {% for block in section.blocks %}
       {% assign featured_image = "" %}

--- a/sections/list-collections.liquid
+++ b/sections/list-collections.liquid
@@ -1,11 +1,24 @@
 {{ "collections.css" | asset_url | stylesheet_tag }}
 
+{%- assign image_fit = settings.collection_card_image_fit -%}
+
+{% comment %} CSS variables start {% endcomment %}
+{%- capture image_variables -%}
+  {%- case image_fit -%}
+    {%- when 'cover' -%}
+      --object-fit: cover;
+    {%- when 'contain' -%}
+      --object-fit: contain;
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
+
 {% if section.settings.title %}
   <h2 class="collections__title collections__title--size-{{ section.settings.title_size }}">{{ section.settings.title }}</h2>
 {% endif %}
 {% paginate collections %}
   {% if collections.size > 0 %}
-    <div class="collections__list">
+    <div class="collections__list{% if settings.collection_card_image_overlay %} collections__list--overlay{% endif %}"{% if image_fit != blank %} style="{{- image_variables | escape -}}"{%- endif -%}>
       {% for collection in collections %}
         {% assign featured_image = "" %}
         {% assign first_product = collection.products | first %}

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -24,9 +24,28 @@
   <h2 class="products__title products__title--size-{{ section.settings.title_size }}">{{ section.settings.title }}</h2>
 {% endif %}
 {% if data_exists %}
+  {% assign card_image_fit = settings.product_card_image_fit %}
+
+  {% comment %} CSS variables start {% endcomment %}
+  {% capture image_variables %}
+    {% case card_image_fit %}
+      {% when 'cover' %}
+        --object-fit: cover;
+      {% when 'contain' %}
+        --object-fit: contain;
+    {% endcase %}
+  {% endcapture %}
+
+  {% if settings.use_focal_images %}
+    {% capture image_variables %}
+      --object-fit: cover;
+    {% endcapture %}
+  {% endif %}
+  {% comment %} CSS variables end {% endcomment %}
+
   {% if section.settings.use_carousel %}
     <div class="carousel carousel--snap-{{ section.settings.snap }}">
-      <div class="carousel__inner {% if section.settings.infinite_scroll %}infinite-scroll{% endif %}">
+      <div class="carousel__inner {% if section.settings.infinite_scroll %}infinite-scroll{% endif %}"{% if card_image_fit != blank %} style="{{- image_variables | escape -}}"{% endif %}>
         {% include "products-inner" %}
       </div>
       <div class="carousel__controls">
@@ -43,7 +62,7 @@
       {% assign per_page = section.settings.paginate_per | times: 1 %}
       {% assign key = section.key %}
       {% paginate data by per_page page_param: key %}
-        <div class="products__inner">
+        <div class="products__inner"{% if card_image_fit != blank %} style="{{- image_variables | escape -}}"{% endif %}>
           {% include "products-inner" %}
         </div>
         {% if paginate.pages > 1 %}
@@ -51,7 +70,7 @@
         {% endif %}
       {% endpaginate %}
     {% else %}
-      <div class="products__inner">
+      <div class="products__inner"{% if card_image_fit != blank %} style="{{- image_variables | escape -}}"{% endif %}>
         {% include "products-inner" %}
       </div>
     {% endif %}

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -5,7 +5,26 @@
 <h1 class="search__title">{{ section.settings.search_results_title }} “{{ query }}”</h1>
 {% endif %}
 {% paginate results %}
-  <div class="search-results {% if results_count == 0 %}no-results{% endif %}">
+  {% assign card_image_fit = settings.product_card_image_fit %}
+
+  {% comment %} CSS variables start {% endcomment %}
+  {% capture image_variables %}
+    {% case card_image_fit %}
+      {% when 'cover' %}
+        --object-fit: cover;
+      {% when 'contain' %}
+        --object-fit: contain;
+    {% endcase %}
+  {% endcapture %}
+
+  {% if settings.use_focal_images %}
+    {% capture image_variables %}
+      --object-fit: cover;
+    {% endcapture %}
+  {% endif %}
+  {% comment %} CSS variables end {% endcomment %}
+
+  <div class="search-results{% if results_count == 0 %} no-results{% endif %}"{% if card_image_fit != blank %} style="{{- image_variables | escape -}}"{% endif %}>
     {% if results_count == 0 %}
       {% include "cleanstate" %}
     {% else %}


### PR DESCRIPTION
This PR introduces a new feature that allows customers to customize image fit settings for collection and product cards.

[Initial issue](https://github.com/booqable/chameleon-theme/pull/328)

## Before:
<img width="325" height="339" alt="Arc 2025-08-05 14 07 09" src="https://github.com/user-attachments/assets/7dcdcf63-a2ae-4a06-bf9d-d2dc890169c4" />


## After:
<img width="313" height="468" alt="Arc 2025-08-05 14 06 52" src="https://github.com/user-attachments/assets/d241a5a3-2085-4254-8914-d0aec7066567" />

