### PR TITLE
Fix: Branding color is ignored for global theme

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -12,7 +12,7 @@
     {{ content_for_header }}
 
     {% render 'fonts', settings: settings %}
-    {% render 'color-palette-styles', settings: settings, branding_color: branding_color %}
+    {% render 'color-palette-styles', settings: settings, branding_color: branding_color, theme_scope: theme_scope %}
 
     {% render 'page-metadata',
       canonical_url: canonical_url,

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -12,7 +12,7 @@
     {{ content_for_header }}
 
     {% render 'fonts', settings: settings %}
-    {% render 'color-palette-styles', settings: settings, branding_color: branding_color, theme_scope: theme_scope %}
+    {% render 'color-palette-styles', settings: settings, branding_color: branding_color, is_local_theme: is_local_theme %}
 
     {% render 'page-metadata',
       canonical_url: canonical_url,

--- a/snippets/color-palette-styles.liquid
+++ b/snippets/color-palette-styles.liquid
@@ -1,6 +1,11 @@
 <style>
   :root {
-    --color-accent-background: {% if settings.primary_color != blank %}{{ settings.primary_color }}{% else %}{{ branding_color }}{% endif %};
+    {% if theme_scope == 'local' %}
+      --color-accent-background: {{ settings.primary_color }};
+    {% else %}
+      --color-accent-background: {{ branding_color }};
+    {% endif %}
+
     --color-accent-foreground: {{ settings.accent_foreground_color }};
     --color-primary-background: {{ settings.primary_background_color }};
     --color-primary-foreground: {{ settings.primary_foreground_color }};
@@ -22,7 +27,7 @@
       --font-body: "{{ settings.body_font.family }}", {{ settings.body_font.fallback_families }};
     {% endif %}
 
-    {% if settings.primary_color != blank %}
+    {% if theme_scope == 'local' %}
       --branding-color: {{ settings.primary_color }};
     {% else %}
       --branding-color: {{ branding_color }};

--- a/snippets/color-palette-styles.liquid
+++ b/snippets/color-palette-styles.liquid
@@ -1,6 +1,6 @@
 <style>
   :root {
-    {% if theme_scope == 'local' %}
+    {% if is_local_theme %}
       --color-accent-background: {{ settings.primary_color }};
     {% else %}
       --color-accent-background: {{ branding_color }};
@@ -27,7 +27,7 @@
       --font-body: "{{ settings.body_font.family }}", {{ settings.body_font.fallback_families }};
     {% endif %}
 
-    {% if theme_scope == 'local' %}
+    {% if is_local_theme %}
       --branding-color: {{ settings.primary_color }};
     {% else %}
       --branding-color: {{ branding_color }};


### PR DESCRIPTION
## Description

This is a follow-up for the https://github.com/booqable/booqable/pull/14408 where the `theme_scope` is defined which is used to define which color should be used as primary