### PR TITLE
Remove style from Kylie

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -216,7 +216,3 @@ bq-product-availability {
   font-family: var(--font-body);
   font-weight: var(--font-weight-semibold);
 }
-
-[data-focus="true"] {
-  box-shadow: 0 0 0 3px #395db899;
-}


### PR DESCRIPTION
We are no longer showing the box shadow on preview, no other theme has this style. 

[Remove style from Kylie](https://linear.app/booqable/issue/SC-2163/remove-style-from-kylie)
