### PR TITLE
Add block identification attributes for theme editor

### DIFF
--- a/assets/carousels.css
+++ b/assets/carousels.css
@@ -23,7 +23,6 @@
   padding: 0 var(--horizontal-padding);
 
   overflow-x: scroll;
-  overflow-y: hidden;
 
   scroll-snap-type: x mandatory;
   scroll-padding: 0 var(--horizontal-padding);

--- a/assets/products.css
+++ b/assets/products.css
@@ -7,6 +7,7 @@
 
 .products .carousel__inner {
   align-items: stretch;
+  padding: 12px 0;
 }
 
 .products__title {
@@ -82,10 +83,6 @@
 @media (min-width: 820px) {
   .products {
     padding: 0 var(--horizontal-padding);
-  }
-
-  .products .carousel__inner {
-    padding: 0;
   }
 
   .products__title {

--- a/sections/collections.liquid
+++ b/sections/collections.liquid
@@ -28,7 +28,7 @@
       {% assign featured_image = "" %}
       {% assign first_product = block.settings.collection.products | first %}
 
-      <a id="{{ block.id }}" href="{{ block.settings.collection.url }}">
+      <a id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" href="{{ block.settings.collection.url }}">
         <div class="collection">
           {% if block.settings.collection.image.url != blank %}
             {% assign featured_image = block.settings.collection.image.url %}

--- a/sections/columns.liquid
+++ b/sections/columns.liquid
@@ -45,7 +45,7 @@
 <div class="columns-{{ section.key }} columns__container columns__container--alignment columns__container--count-{{ section.settings.columns_count }}">
   {% if section.blocks.size >= 1 and column_exists %}
     {% for block in section.blocks %}
-      <div id="{{ block.id }}" class="columns__column post">
+      <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="columns__column post">
         {% if block.settings.image.url != blank %}
           {% if block.settings.image_border_radius == true %}
             {% assign class = "post__image post__image--border-radius" %}

--- a/sections/form.liquid
+++ b/sections/form.liquid
@@ -56,12 +56,12 @@
   {% for block in section.blocks %}
     {% case block.type %}
       {% when "heading" %}
-        <h1 id="{{ block.id }}" class="form__title form__title--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</h1>
+        <h1 id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="form__title form__title--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</h1>
       {% when "text" %}
-        <p id="{{ block.id }}" class="form__text form__text--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</p>
+        <p id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="form__text form__text--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</p>
       {% when "button" %}
         <div class="form__button-container form__button-container--align-{{ section.settings.content_justify }}">
-          <a id="{{ block.id }}" class="bq-button bq-button--size-{{ block.settings.size }} {% if block.settings.use_solid_button %}bq-button--solid{% endif %}" href="{{ block.settings.url }}" {% if block.settings.use_new_tab %}target="_blank"{% endif %}>
+          <a id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="bq-button bq-button--size-{{ block.settings.size }} {% if block.settings.use_solid_button %}bq-button--solid{% endif %}" href="{{ block.settings.url }}" {% if block.settings.use_new_tab %}target="_blank"{% endif %}>
             {{ block.settings.text | escape }}
           </a>
         </div>

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -87,9 +87,9 @@
     {% for block in section.blocks %}
       {% case block.type %}
         {% when "heading" %}
-          <h1 id="{{ block.id }}" class="image-banner__title image-banner__title--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</h1>
+          <h1 id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="image-banner__title image-banner__title--size-{{ block.settings.size }}">{{ block.settings.text | escape }}</h1>
         {% when "text" %}
-          <p id="{{ block.id }}" class="image-banner__text image-banner__text--size-{{ block.settings.size }}">{{ block.settings.text }}</p>
+          <p id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="image-banner__text image-banner__text--size-{{ block.settings.size }}">{{ block.settings.text }}</p>
       {% endcase %}
     {% endfor %}
 
@@ -97,7 +97,7 @@
       {% for block in section.blocks %}
         {% case block.type %}
           {% when "button" %}
-              <a id="{{ block.id }}" class="bq-button bq-button--size-{{ block.settings.size }} {% if block.settings.use_solid_button %}bq-button--solid{% endif %}" href="{{ block.settings.url }}" {% if block.settings.use_new_tab %}target="_blank"{% endif %}>
+              <a id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="bq-button bq-button--size-{{ block.settings.size }} {% if block.settings.use_solid_button %}bq-button--solid{% endif %}" href="{{ block.settings.url }}" {% if block.settings.use_new_tab %}target="_blank"{% endif %}>
                 {{ block.settings.text | escape }}
               </a>
         {% endcase %}
@@ -113,7 +113,7 @@
             {% assign color = branding_color %}
           {% endif %}
 
-          <div id="{{ block.id }}" class="date-location">
+          <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="date-location">
             <bq-date-picker branding-color="{{ color }}"></bq-date-picker>
           </div>
       {% endcase %}

--- a/sections/logos.liquid
+++ b/sections/logos.liquid
@@ -18,7 +18,7 @@
       {% for block in section.blocks %}
         {% assign image = block.settings.image %}
 
-        <div class="logos__image-wrapper" id="{{- block.id -}}">
+        <div class="logos__image-wrapper" id="{{- block.id -}}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}">
           {% if image.url != blank %}
             {{ block.settings.image.url | image_tag:
               loading: 'lazy',

--- a/sections/testimonials.liquid
+++ b/sections/testimonials.liquid
@@ -32,7 +32,7 @@
         {% assign stars_empty = block.settings.stars | plus: 1 %}
 
         {% if block.settings.description != blank %}
-          <blockquote id="{{ block.id }}" class="testimonials__blockquote">
+          <blockquote id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="testimonials__blockquote">
             <div class="testimonials__stars">
               {% for i in (1..stars_full) %}
                 <span class="testimonials__star">

--- a/sections/tiles.liquid
+++ b/sections/tiles.liquid
@@ -40,7 +40,7 @@
 
   <div class="tiles__items">
     {% for block in section.blocks %}
-      <div id="{{ block.id }}" class="tiles__item">
+      <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="tiles__item">
         {% if block.settings.icon != "empty" and block.settings.heading != blank or block.settings.icon != "empty" and block.settings.text != blank %}
           <div class="tiles__icon">
             <i class="fa fa-{{ block.settings.icon }}"></i>

--- a/snippets/accordion-block.liquid
+++ b/snippets/accordion-block.liquid
@@ -19,7 +19,7 @@
 {% if blocks.size > 0 %}
   <ul class="accordion-block">
     {% for block in blocks %}
-      <li class="accordion-block__item" id="{{- block.id -}}">
+      <li class="accordion-block__item" id="{{- block.id -}}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}">
         {% if block.settings.heading != blank %}
           <input
             {% if behavior == "single" %}type="radio"{% else %}type="checkbox"{% endif %}

--- a/snippets/products-inner.liquid
+++ b/snippets/products-inner.liquid
@@ -16,7 +16,7 @@
     {% else %}
       {% assign focal = nil %}
     {% endif %}
-    <div id="{% if data_type == 'blocks' %}{{ item.id }}{% else %}{{ product.id }}{% endif %}" class="product {% if section.settings.use_carousel %}carousel__item{% endif %}">
+    <div id="{% if data_type == 'blocks' %}{{ item.id }}{% else %}{{ product.id }}{% endif %}" {% if data_type == 'blocks' %}data-block-key="{{ item.id }}" data-block-name="{{ item.name }}"{% endif %} class="product {% if section.settings.use_carousel %}carousel__item{% endif %}">
       <a href="{{ product.url }}" class="product__image-container">{% if image != blank %}{{ image.url | image_tag:
         loading: 'lazy',
         class: 'product__image',


### PR DESCRIPTION
Add data-block-key and data-block-name attributes to all block elements across section and snippet templates to enable block identification in the theme editor preview. Also fix carousel overflow styling to properly display controls on product carousels during preview.


[Actions on preview blocks](https://linear.app/booqable/issue/SC-2160/actions-on-preview-blocks)