### PR TITLE
Fix: Product schema

### DIFF
--- a/templates/aero/product.json
+++ b/templates/aero/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/arc/product.json
+++ b/templates/arc/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/float/product.json
+++ b/templates/float/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/myst/product.json
+++ b/templates/myst/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/reverb/product.json
+++ b/templates/reverb/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/summit/product.json
+++ b/templates/summit/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/torque/product.json
+++ b/templates/torque/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/traverse/product.json
+++ b/templates/traverse/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/velo/product.json
+++ b/templates/velo/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },

--- a/templates/wayfarer/product.json
+++ b/templates/wayfarer/product.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "description_label": "Description",
-        "description_placement": "bottom",
+        "description_placement": "bottom"
       },
       "disabled": null
     },


### PR DESCRIPTION
Previously we had an extra comma in the product.json schema of all Kylie variants. This caused a validation error in ShopNext:Asset. Since installation of individual variants is wrapped in a database transaction this prevented theme updating.

Since themes could not be updated, this is a likely cause of [SC-2170](https://linear.app/booqable/issue/SC-2170/product-images-not-displayed-after-recent-issues)